### PR TITLE
InvSee v1.0

### DIFF
--- a/.poggit.yml
+++ b/.poggit.yml
@@ -6,6 +6,6 @@ projects:
     path: ""
     libs:
       - src: muqsit/InvMenu/InvMenu
-        version: ^2.0
+        version: ^2.0.0
         branch: master
 ...

--- a/.poggit.yml
+++ b/.poggit.yml
@@ -6,6 +6,6 @@ projects:
     path: ""
     libs:
       - src: muqsit/InvMenu/InvMenu
-        version: ^1.1.3
-        branch: v1.1.3
+        version: ^2.0
+        branch: master
 ...

--- a/plugin.yml
+++ b/plugin.yml
@@ -19,6 +19,10 @@ permissions:
           invsee.inventory.modify:
             default: op
             description: "Allows modifying a player's inventory."
+            children:
+              invsee.inventory.modify.self:
+                default: true
+                description: "Allows modifying your own inventory."
       invsee.enderinventory:
         default: false
         description: "Grants complete access to managing another player's ender inventory."
@@ -29,3 +33,7 @@ permissions:
           invsee.enderinventory.modify:
             default: op
             description: "Allows modifying a player's ender inventory."
+            children:
+              invsee.enderinventory.modify.self:
+                default: true
+                description: "Allows modifying your own ender inventory."

--- a/src/BlockHorizons/InvSee/EventListener.php
+++ b/src/BlockHorizons/InvSee/EventListener.php
@@ -1,9 +1,16 @@
 <?php
 namespace BlockHorizons\InvSee;
 
+use BlockHorizons\InvSee\inventories\InvSeeInventory;
+
+use pocketmine\event\entity\EntityArmorChangeEvent;
+use pocketmine\event\entity\EntityInventoryChangeEvent;
+use pocketmine\event\inventory\InventoryTransactionEvent;
 use pocketmine\event\Listener;
 use pocketmine\event\player\PlayerJoinEvent;
 use pocketmine\event\player\PlayerQuitEvent;
+use pocketmine\inventory\transaction\action\SlotChangeAction;
+use pocketmine\Player;
 
 class EventListener implements Listener {
 
@@ -20,7 +27,7 @@ class EventListener implements Listener {
 	 * @ignoreCancelled true
 	 */
 	public function onPlayerJoin(PlayerJoinEvent $event): void {
-		$this->handler->enableSyncing($event->getPlayer());
+		$this->handler->handleJoin($event->getPlayer());
 	}
 
 	/**
@@ -28,6 +35,49 @@ class EventListener implements Listener {
 	 * @priority MONITOR
 	 */
 	public function onPlayerQuit(PlayerQuitEvent $event): void {
-		$this->handler->disableSyncing($event->getPlayer());
+		$this->handler->handleQuit($event->getPlayer());
+	}
+
+	/**
+	 * @param EntityArmorChangeEvent $event
+	 * @priority MONITOR
+	 * @ignoreCancelled true
+	 */
+	public function onEntityArmorChange(EntityArmorChangeEvent $event): void {
+		$player = $event->getEntity();
+		if($player instanceof Player){
+			$this->handler->syncPlayerAction($player, new SlotChangeAction($player->getArmorInventory(), $event->getSlot(), $event->getOldItem(), $event->getNewItem()));
+		}
+	}
+
+	/**
+	 * @param EntityInventoryChangeEvent $event
+	 * @priority MONITOR
+	 * @ignoreCancelled true
+	 */
+	public function onEntityInventoryChange(EntityInventoryChangeEvent $event): void {
+		$player = $event->getEntity();
+		if($player instanceof Player){
+			$this->handler->syncPlayerAction($player, new SlotChangeAction($player->getInventory(), $event->getSlot(), $event->getOldItem(), $event->getNewItem()));
+		}
+	}
+
+	/**
+	 * @param InventoryTransactionEvent $event
+	 * @priority MONITOR
+	 * @ignoreCancelled true
+	 */
+	public function onInventoryTransaction(InventoryTransactionEvent $event): void {
+		$transaction = $event->getTransaction();
+		foreach($transaction->getActions() as $action) {
+			if($action instanceof SlotChangeAction){
+				$inventory = $action->getInventory();
+				if($inventory instanceof InvSeeInventory){
+					$this->handler->syncSpyerAction($action);
+				}else{
+					$this->handler->syncPlayerAction($transaction->getSource(), $action);
+				}
+			}
+		}
 	}
 }

--- a/src/BlockHorizons/InvSee/EventListener.php
+++ b/src/BlockHorizons/InvSee/EventListener.php
@@ -24,7 +24,6 @@ class EventListener implements Listener {
 	/**
 	 * @param PlayerJoinEvent $event
 	 * @priority MONITOR
-	 * @ignoreCancelled true
 	 */
 	public function onPlayerJoin(PlayerJoinEvent $event): void {
 		$this->handler->handleJoin($event->getPlayer());

--- a/src/BlockHorizons/InvSee/InventoryHandler.php
+++ b/src/BlockHorizons/InvSee/InventoryHandler.php
@@ -1,329 +1,98 @@
 <?php
 namespace BlockHorizons\InvSee;
 
-use muqsit\invmenu\inventories\BaseFakeInventory;
-use muqsit\invmenu\InvMenu;
+use BlockHorizons\InvSee\inventories\InvSeeEnderInventory;
+use BlockHorizons\InvSee\inventories\InvSeeEnderInventoryProcessor;
+use BlockHorizons\InvSee\inventories\InvSeeInventory;
+use BlockHorizons\InvSee\inventories\InvSeePlayerInventory;
+use BlockHorizons\InvSee\utils\SpyingPlayerData;
+
 use muqsit\invmenu\InvMenuHandler;
 
 use pocketmine\inventory\transaction\action\SlotChangeAction;
 use pocketmine\item\Item;
-use pocketmine\nbt\tag\ListTag;
 use pocketmine\Player;
 
 class InventoryHandler {
 
-	const PLAYER_INVENTORY_SIZE = 36;
+	const TYPE_ENDER_INVENTORY = InvSeeEnderInventory::class;
+	const TYPE_PLAYER_INVENTORY = InvSeePlayerInventory::class;
 
-	const ARMOR_INVENTORY_OFFSET = 100;
+	/** @var Loader */
+	private $loader;
 
-	const ARMOR_INVENTORY_MAP = [ //[pmmp "Inventory" tag slot] => (InvSee's slot)
-		self::ARMOR_INVENTORY_OFFSET => 47,
-		self::ARMOR_INVENTORY_OFFSET + 1 => 48,
-		self::ARMOR_INVENTORY_OFFSET + 2 => 50,
-		self::ARMOR_INVENTORY_OFFSET + 3 => 51,
-	];
+	/** @var SpyingPlayerData[] */
+	private $spying = [];
 
-	/** @var InvMenu[] */
-	private $ender_menus = [];
-
-	/** @var string[] */
-	private $player_uuids = [];
-
-	/** @var string[] */
-	private $viewings = [];
-
-	/** @var Server */
-	private $server;
-
-	public function __construct(Loader $loader) {
+	public function __construct(Loader $loader){
 		if(!InvMenuHandler::isRegistered()) {
 			InvMenuHandler::register($loader);
 		}
 
-		$this->server = $loader->getServer();
+		$this->loader = $loader;
 	}
 
-	/**
-	 * Enables real-time syncing of inventory transactions for
-	 * a player's inventory.
-	 *
-	 * When enabled, the inventory changes will directly be set
-	 * to the player's inventory rather than saving into
-	 * players/player.dat file.
-	 *
-	 * @param Player $player
-	 */
-	public function enableSyncing(Player $player): void {
-		$this->player_uuids[$username = $player->getLowerCaseName()] = $player->getRawUniqueId();
-
-		if(isset($this->menus[$username])) {
-			$player->getInventory()->setContents($this->menus[$username]->getInventory()->getContents());
+	public function handleJoin(Player $player) : void{
+		if(isset($this->spying[$key = $player->getLowerCaseName()])){
+			$this->spying[$key]->onJoin($player);
 		}
 
-		if(isset($this->ender_menus[$username])) {
-			$player->getEnderChestInventory()->setContents($this->ender_menus[$username]->getInventory()->getContents());
+		$player->getEnderChestInventory()->setEventProcessor(new InvSeeEnderInventoryProcessor($player));
+	}
+
+	public function handleQuit(Player $player) : void{
+		if(isset($this->spying[$key = $player->getLowerCaseName()])){
+			$this->spying[$key]->onQuit($player);
 		}
 	}
 
-	/**
-	 * Disables real-time syncing of inventory transactions for
-	 * a player's inventory.
-	 *
-	 * When disabled, the inventory changes will directly be set
-	 * to players/player.dat file rather than updating the
-	 * player's inventory.
-	 *
-	 * @param Player $player
-	 */
-	public function disableSyncing(Player $player): void {
-		unset($this->player_uuids[$player->getLowerCaseName()], $this->viewings[$player->getRawUniqueId()]);
-	}
-
-	/**
-	 * Updates player's inventory instance with the inventory
-	 * changes.
-	 *
-	 * @param Player $player
-	 * @param Item $itemClicked
-	 * @param Item $itemClickedWith
-	 * @param SlotChangeAction $inventoryAction
-	 */
-	public function syncInventory(Player $player, Item $itemClicked, Item $itemClickedWith, SlotChangeAction $inventoryAction): bool {
-		if(isset($this->viewings[$key = $player->getRawUniqueId()])) {
-			if(!$player->hasPermission("invsee.inventory.modify")) {
-				return false;
+	public function syncSpyerAction(SlotChangeAction $action) : void{
+		$inventory = $action->getInventory();
+		if(isset($this->spying[$key = $inventory->getSpying()])){
+			$player = $this->spying[$key]->getPlayer();
+			if($player !== null){
+				$inventory->syncSpyerAction($player, $action);
 			}
-
-			$slot = $inventoryAction->getSlot();
-			if($slot >= self::PLAYER_INVENTORY_SIZE && ($slot = array_search($slot, self::ARMOR_INVENTORY_MAP, true)) === false) {
-				return false;//invalid slot
-			}
-
-			$player = isset($this->player_uuids[$uuid = $this->viewings[$key]]) ? $this->server->getPlayerByRawUUID($this->player_uuids[$uuid]) : null;
-			if($player === null) {
-				return true;
-			}
-
-			if(isset(self::ARMOR_INVENTORY_MAP[$slot])) {
-				return $player->getArmorInventory()->setItem($slot - 100, $inventoryAction->getTargetItem());
-			}
-
-			return $player->getInventory()->setItem($slot, $inventoryAction->getTargetItem());
 		}
-
-		return true;
 	}
 
-	/**
-	 * Updates player's ender inventory instance with the
-	 * ender inventory changes.
-	 *
-	 * @param Player $player
-	 * @param Item $itemClicked
-	 * @param Item $itemClickedWith
-	 * @param SlotChangeAction $inventoryAction
-	 */
-	public function syncEnderInventory(Player $player, Item $itemClicked, Item $itemClickedWith, SlotChangeAction $inventoryAction): bool {
-		if(isset($this->viewings[$key = $player->getRawUniqueId()])) {
-			if(!$player->hasPermission("invsee.enderinventory.modify")) {
-				return false;
-			}
-
-			$player = isset($this->player_uuids[$uuid = $this->viewings[$key]]) ? $this->server->getPlayerByRawUUID($this->player_uuids[$uuid]) : null;
-			return $player === null || $player->getEnderChestInventory()->setItem($inventoryAction->getSlot(), $inventoryAction->getTargetItem());
-		}
-		return true;
-	}
-
-	/**
-	 * Called when an inventory viewer stops viewing an
-	 * inventory.
-	 * InvSee will attempt to save inventory data to file
-	 * if the player is offline.
-	 *
-	 * @param Player $player
-	 * @param BaseFakeInventory $inventory
-	 */
-	public function onInvClose(Player $player, BaseFakeInventory $inventory): void {
-		if(isset($this->viewings[$uuid = $player->getRawUniqueId()])) {
-			$viewing = $this->viewings[$uuid];
-			unset($this->viewings[$uuid]);
-
-			if(empty($inventory->getViewers())) {
-				unset($this->menus[$viewing]);
-
-				if(!isset($this->player_uuids[$viewing])) {//player changed offline player's inventory
-					$tag = new ListTag("Inventory");
-					foreach($inventory->getContents() as $slot => $item) {
-						if($slot >= self::PLAYER_INVENTORY_SIZE) {
-							$slot = array_search($slot, self::ARMOR_INVENTORY_MAP, true);
-							if($slot === false) {
-								continue;
-							}
-						}
-
-                        $tag->push($item->nbtSerialize($slot));
-					}
-
-					$nbt = $this->server->getOfflinePlayerData($viewing);
-					$nbt->setTag($tag);
-					$this->server->saveOfflinePlayerData($viewing, $nbt);
+	public function syncPlayerAction(Player $player, SlotChangeAction $action) : void{
+		$inventory = $action->getInventory();
+		if(isset($this->spying[$key = $player->getLowerCaseName()])){
+			foreach($this->spying[$key]->getAll() as $menu){
+				$menu_inventory = $menu->getInventory();
+				if($menu_inventory->canSpyInventory($inventory)){
+					$menu_inventory->syncPlayerAction($action);
 				}
 			}
 		}
 	}
 
-	/**
-	 * Called when an inventory viewer stops viewing an
-	 * ender inventory.
-	 * InvSee will attempt to save inventory data to file
-	 * if the player is offline.
-	 *
-	 * @param Player $player
-	 * @param BaseFakeInventory $inventory
-	 */
-	public function onEnderInvClose(Player $player, BaseFakeInventory $inventory): void {
-		if(isset($this->viewings[$uuid = $player->getRawUniqueId()])) {
-			$viewing = $this->viewings[$uuid];
-			unset($this->viewings[$uuid]);
-
-			if(empty($inventory->getViewers())) {
-				unset($this->ender_menus[$viewing]);
-
-				if(!isset($this->player_uuids[$viewing])) {//player changed offline player's inventory
-					$tag = new ListTag("EnderChestInventory");
-					foreach($inventory->getContents() as $slot => $item) {
-						$tag->push($item->nbtSerialize($slot));
-					}
-
-					$nbt = $this->server->getOfflinePlayerData($viewing);
-					$nbt->setTag($tag);
-					$this->server->saveOfflinePlayerData($viewing, $nbt);
-				}
+	public function onInventoryClose(Player $player, InvSeeInventory $inventory) : void{
+		if(count($inventory->getViewers()) <= 1){
+			if($this->spying[$key = $inventory->getSpying()]->getPlayer() === null){
+				$inventory->syncOffline();
 			}
+
+			unset($this->spying[$key]);
 		}
 	}
 
-	/**
-	 * Opens a player's inventory to the viewer.
-	 *
-	 * @param Player $viewer
-	 * @param string $player
-	 *
-	 * @return bool whether the inventory was sent to
-	 * the viewer successfully.
-	 */
-	public function viewInventory(Player $viewer, string $player): bool {
-		$player = strtolower($player);
-		if($viewer->getLowerCaseName() === $player) { //prevents weird transaction issues when grouping separated items
-			return false;
-		}
+	public function send(Player $opener, string $player, string $inventory_class) : bool{
+		$data = $this->spying[$key = strtolower($player)] ?? ($this->spying[$key] = new SpyingPlayerData($player));
 
-		$this->viewings[$viewer->getRawUniqueId()] = $player;
-
-		if(isset($this->menus[$player])) {
-			$this->menus[$player]->send($viewer);
-			return true;
-		}
-
-		$this->menus[$player] = $menu = $this->createInvMenu();
-
-		$player_instance = $this->server->getPlayerExact($player);
-		if($player_instance !== null) {
-			$menu->setName($player_instance->getName() . "'s Inventory");
-
-			$inventory = $menu->getInventory();
-			foreach($player_instance->getInventory()->getContents() as $slot => $item) {
-				$inventory->setItem($slot, $item, false);
-			}
-
-			foreach($player_instance->getArmorInventory()->getContents() as $slot => $item) {
-				$inventory->setItem(self::ARMOR_INVENTORY_MAP[self::ARMOR_INVENTORY_OFFSET + $slot], $item, false);
-			}
-		} else {
+		$menu = $data->get($inventory_class);
+		if($menu === null){
+			$menu = $data->create($inventory_class);
 			$menu->setName($player . "'s Inventory");
-			if (is_file($this->server->getDataPath() . "players/" . $player . ".dat")) {
-				$tag = $this->server->getOfflinePlayerData($player)->getListTag("Inventory");
-
-				$inventory = $menu->getInventory();
-				foreach($tag as $nbt) {
-					$slot = $nbt->getByte("Slot");
-					$inventory->setItem(self::ARMOR_INVENTORY_MAP[$slot] ?? $slot, Item::nbtDeserialize($nbt), false);
-				}
-			}
+			$menu->setInventoryCloseListener([$this, "onInventoryClose"]);
+			$menu->setListener([$this, "handleSpyInventoryTransaction"]);
 		}
 
-		$menu->send($viewer);
-		return true;
+		return $menu->send($opener);
 	}
 
-	/**
-	 * Opens a player's ender inventory to the
-	 * viewer.
-	 *
-	 * @param Player $viewer
-	 * @param string $player
-	 *
-	 * @return bool whether the inventory was sent to
-	 * the viewer successfully.
-	 */
-	public function viewEnderInventory(Player $viewer, string $player): bool {
-		$player = strtolower($player);
-		$this->viewings[$viewer->getRawUniqueId()] = $player;
-
-		if(isset($this->ender_menus[$player])) {
-			$this->ender_menus[$player]->send($viewer);
-			return true;
-		}
-
-		$this->ender_menus[$player] = $menu = $this->createEnderInvMenu();
-
-		$player_instance = $this->server->getPlayerExact($player);
-		if($player_instance !== null) {
-			$menu->setName($player_instance->getName() . "'s Ender Inventory");
-			$menu->getInventory()->setContents($player_instance->getEnderChestInventory()->getContents(), false);
-		} else {
-			$menu->setName($player . "'s Ender Inventory");
-			if (is_file($this->server->getDataPath() . "players/" . $player . ".dat")) {
-				$tag = $this->server->getOfflinePlayerData($player)->getListTag("EnderChestInventory");
-
-				$items = [];
-				foreach($tag as $nbt) {
-					$items[$nbt->getByte("Slot")] = Item::nbtDeserialize($nbt);
-				}
-				$menu->getInventory()->setContents($items, false);
-			}
-		}
-
-		$menu->send($viewer);
-		return true;
-	}
-
-	private function createInvMenu(): InvMenu {
-		$menu = InvMenu::create(InvMenu::TYPE_DOUBLE_CHEST);
-
-		$inventory = $menu->getInventory();
-		$size = $inventory->getSize();
-
-		$barrier_item = Item::get(Item::STAINED_GLASS_PANE, 15);
-		$barrier_item->setCustomName(" ");
-
-		$armor_slots = array_flip(self::ARMOR_INVENTORY_MAP);
-
-		for($i = self::PLAYER_INVENTORY_SIZE; $i < $size; ++$i) {
-			if(!isset($armor_slots[$i])) {
-				$inventory->setItem($i, $barrier_item, false);
-			}
-		}
-
-		$menu->setListener([$this, "syncInventory"]);
-		$menu->setInventoryCloseListener([$this, "onInvClose"]);
-		return $menu;
-	}
-
-	private function createEnderInvMenu(): InvMenu {
-		return InvMenu::create(InvMenu::TYPE_CHEST)
-			->setListener([$this, "syncEnderInventory"])
-		->setInventoryCloseListener([$this, "onEnderInvClose"]);
+	public function handleSpyInventoryTransaction(Player $player, Item $itemClicked, Item $itemClickedWith, SlotChangeAction $action) : bool{
+		return $action->getInventory()->canModifySlot($player, $action->getSlot());
 	}
 }

--- a/src/BlockHorizons/InvSee/InventoryHandler.php
+++ b/src/BlockHorizons/InvSee/InventoryHandler.php
@@ -32,7 +32,7 @@ class InventoryHandler {
 		$this->loader = $loader;
 	}
 
-	public function handleJoin(Player $player) : void{
+	public function handleJoin(Player $player): void {
 		if(isset($this->spying[$key = $player->getLowerCaseName()])){
 			$this->spying[$key]->onJoin($player);
 		}
@@ -40,13 +40,13 @@ class InventoryHandler {
 		$player->getEnderChestInventory()->setEventProcessor(new InvSeeEnderInventoryProcessor($player));
 	}
 
-	public function handleQuit(Player $player) : void{
+	public function handleQuit(Player $player): void {
 		if(isset($this->spying[$key = $player->getLowerCaseName()])){
 			$this->spying[$key]->onQuit($player);
 		}
 	}
 
-	public function syncSpyerAction(SlotChangeAction $action) : void{
+	public function syncSpyerAction(SlotChangeAction $action): void {
 		$inventory = $action->getInventory();
 		if(isset($this->spying[$key = $inventory->getSpying()])){
 			$player = $this->spying[$key]->getPlayer();
@@ -56,7 +56,7 @@ class InventoryHandler {
 		}
 	}
 
-	public function syncPlayerAction(Player $player, SlotChangeAction $action) : void{
+	public function syncPlayerAction(Player $player, SlotChangeAction $action): void {
 		$inventory = $action->getInventory();
 		if(isset($this->spying[$key = $player->getLowerCaseName()])){
 			foreach($this->spying[$key]->getAll() as $menu){
@@ -68,7 +68,7 @@ class InventoryHandler {
 		}
 	}
 
-	public function onInventoryClose(Player $player, InvSeeInventory $inventory) : void{
+	public function onInventoryClose(Player $player, InvSeeInventory $inventory): void {
 		if(count($inventory->getViewers()) <= 1){
 			if($this->spying[$key = $inventory->getSpying()]->getPlayer() === null){
 				$inventory->syncOffline();
@@ -78,7 +78,7 @@ class InventoryHandler {
 		}
 	}
 
-	public function send(Player $opener, string $player, string $inventory_class) : bool{
+	public function send(Player $opener, string $player, string $inventory_class): bool {
 		$data = $this->spying[$key = strtolower($player)] ?? ($this->spying[$key] = new SpyingPlayerData($player));
 
 		$menu = $data->get($inventory_class);
@@ -92,7 +92,7 @@ class InventoryHandler {
 		return $menu->send($opener);
 	}
 
-	public function handleSpyInventoryTransaction(Player $player, Item $itemClicked, Item $itemClickedWith, SlotChangeAction $action) : bool{
+	public function handleSpyInventoryTransaction(Player $player, Item $itemClicked, Item $itemClickedWith, SlotChangeAction $action): bool {
 		return $action->getInventory()->canModifySlot($player, $action->getSlot());
 	}
 }

--- a/src/BlockHorizons/InvSee/commands/BaseCommand.php
+++ b/src/BlockHorizons/InvSee/commands/BaseCommand.php
@@ -116,7 +116,7 @@ abstract class BaseCommand extends Command implements PluginIdentifiableCommand 
 		}
 	}
 
-	public function sendPermissionMessage(CommandSender $sender) : void{
+	public function sendPermissionMessage(CommandSender $sender): void {
 		$sender->sendMessage(TextFormat::RED . "You don't have permission to use this command.");
 	}
 

--- a/src/BlockHorizons/InvSee/commands/BaseCommand.php
+++ b/src/BlockHorizons/InvSee/commands/BaseCommand.php
@@ -23,8 +23,8 @@ abstract class BaseCommand extends Command implements PluginIdentifiableCommand 
 		$commands = [];
 
 		foreach([
-			EnderInvSeeCommand::class => ["enderinvsee", "View a player's ender chest inventory.", "/enderinvsee <player>", "invsee.enderinventory.view"],
-			InvSeeCommand::class => ["invsee", "View a player's inventory.", "/invsee <player>", "invsee.inventory.view"]
+			EnderInvSeeCommand::class 	=> ["enderinvsee", "View a player's ender chest inventory.", "/enderinvsee <player>", "invsee.enderinventory.view"],
+			InvSeeCommand::class 		=> ["invsee", "View a player's inventory.", "/invsee <player>", "invsee.inventory.view"]
 		] as $class => [$name, $desc, $usage, $perm]) {
 			$commands[$name] = new $class($loader, $name, $desc, $usage);
 			$commands[$name]->setPermission($perm);
@@ -114,6 +114,10 @@ abstract class BaseCommand extends Command implements PluginIdentifiableCommand 
 			$sender->sendMessage(str_replace("/" . $this->getName(), "/" . $commandLabel, $this->getUsage()));
 			return;
 		}
+	}
+
+	public function sendPermissionMessage(CommandSender $sender) : void{
+		$sender->sendMessage(TextFormat::RED . "You don't have permission to use this command.");
 	}
 
 	/**

--- a/src/BlockHorizons/InvSee/commands/EnderInvSeeCommand.php
+++ b/src/BlockHorizons/InvSee/commands/EnderInvSeeCommand.php
@@ -1,6 +1,8 @@
 <?php
 namespace BlockHorizons\InvSee\commands;
 
+use BlockHorizons\InvSee\InventoryHandler;
+
 use pocketmine\command\CommandSender;
 use pocketmine\utils\TextFormat;
 
@@ -15,7 +17,7 @@ class EnderInvSeeCommand extends BaseCommand {
 			return false;
 		}
 
-		if(!$this->getLoader()->getInventoryHandler()->viewEnderInventory($sender, $args[0])) {
+		if(!$this->getLoader()->getInventoryHandler()->send($sender, $args[0], InventoryHandler::TYPE_ENDER_INVENTORY)) {
 			$sender->sendMessage(TextFormat::RED . "You cannot view this inventory.");
 			return true;
 		}

--- a/src/BlockHorizons/InvSee/commands/InvSeeCommand.php
+++ b/src/BlockHorizons/InvSee/commands/InvSeeCommand.php
@@ -1,6 +1,8 @@
 <?php
 namespace BlockHorizons\InvSee\commands;
 
+use BlockHorizons\InvSee\InventoryHandler;
+
 use pocketmine\command\CommandSender;
 use pocketmine\utils\TextFormat;
 
@@ -15,7 +17,7 @@ class InvSeeCommand extends BaseCommand {
 			return false;
 		}
 
-		if(!$this->getLoader()->getInventoryHandler()->viewInventory($sender, $args[0])) {
+		if(!$this->getLoader()->getInventoryHandler()->send($sender, $args[0], InventoryHandler::TYPE_PLAYER_INVENTORY)) {
 			$sender->sendMessage(TextFormat::RED . "You cannot view this inventory.");
 			return true;
 		}

--- a/src/BlockHorizons/InvSee/inventories/InvSeeEnderInventory.php
+++ b/src/BlockHorizons/InvSee/inventories/InvSeeEnderInventory.php
@@ -1,0 +1,65 @@
+<?php
+namespace BlockHorizons\InvSee\inventories;
+
+use muqsit\invmenu\inventories\ChestInventory;
+
+use pocketmine\inventory\EnderInventory;
+use pocketmine\inventory\Inventory;
+use pocketmine\inventory\transaction\action\SlotChangeAction;
+use pocketmine\item\Item;
+use pocketmine\nbt\tag\ListTag;
+use pocketmine\Player;
+use pocketmine\Server;
+
+class InvSeeEnderInventory extends ChestInventory implements InvSeeInventory{
+	use InvSeeInventoryTrait;
+
+	public function canSpyInventory(Inventory $inventory) : bool{
+		return $inventory instanceof EnderInventory;
+	}
+
+	public function canModifySlot(Player $player, int $slot) : bool{
+		return $player->hasPermission($this->getSpying() === $player->getLowerCaseName() ? "invsee.enderinventory.modify.self" : "invsee.enderinventory.modify");
+	}
+
+	public function syncOnline(Player $player) : void{
+		$player->getEnderChestInventory()->setContents($this->getContents());
+	}
+
+	public function syncOffline() : void{
+		$server = Server::getInstance();
+
+		$contents = [];
+		foreach($this->getContents() as $slot => $item){
+			$contents[] = $item->nbtSerialize($slot);
+		}
+
+		$nbt = $server->getOfflinePlayerData($this->spying);
+		$nbt->setTag(new ListTag("EnderChestInventory", $contents));
+		$server->saveOfflinePlayerData($this->spying, $nbt);
+	}
+
+	public function syncPlayerAction(SlotChangeAction $action) : void{
+		$this->setItem($action->getSlot(), $action->getTargetItem());
+	}
+
+	public function syncSpyerAction(Player $spying, SlotChangeAction $action) : void{
+		$spying->getEnderChestInventory()->setItem($action->getSlot(), $action->getTargetItem());
+	}
+
+	public function getSpyerContents() : array{
+		$server = Server::getInstance();
+		$player_instance = $server->getPlayerExact($this->spying);
+
+		if($player_instance !== null){
+			return $player_instance->getEnderChestInventory()->getContents();
+		}
+
+		$contents = [];
+		foreach($server->getOfflinePlayerData($this->spying)->getListTag("EnderChestInventory") as $nbt){
+			$contents[$nbt->getByte("Slot")] = Item::nbtDeserialize($nbt);
+		}
+
+		return $contents;
+	}
+}

--- a/src/BlockHorizons/InvSee/inventories/InvSeeEnderInventory.php
+++ b/src/BlockHorizons/InvSee/inventories/InvSeeEnderInventory.php
@@ -11,7 +11,7 @@ use pocketmine\nbt\tag\ListTag;
 use pocketmine\Player;
 use pocketmine\Server;
 
-class InvSeeEnderInventory extends ChestInventory implements InvSeeInventory{
+class InvSeeEnderInventory extends ChestInventory implements InvSeeInventory {
 	use InvSeeInventoryTrait;
 
 	public function canSpyInventory(Inventory $inventory): bool {

--- a/src/BlockHorizons/InvSee/inventories/InvSeeEnderInventory.php
+++ b/src/BlockHorizons/InvSee/inventories/InvSeeEnderInventory.php
@@ -14,19 +14,19 @@ use pocketmine\Server;
 class InvSeeEnderInventory extends ChestInventory implements InvSeeInventory{
 	use InvSeeInventoryTrait;
 
-	public function canSpyInventory(Inventory $inventory) : bool{
+	public function canSpyInventory(Inventory $inventory): bool {
 		return $inventory instanceof EnderInventory;
 	}
 
-	public function canModifySlot(Player $player, int $slot) : bool{
+	public function canModifySlot(Player $player, int $slot): bool {
 		return $player->hasPermission($this->getSpying() === $player->getLowerCaseName() ? "invsee.enderinventory.modify.self" : "invsee.enderinventory.modify");
 	}
 
-	public function syncOnline(Player $player) : void{
+	public function syncOnline(Player $player): void {
 		$player->getEnderChestInventory()->setContents($this->getContents());
 	}
 
-	public function syncOffline() : void{
+	public function syncOffline(): void {
 		$server = Server::getInstance();
 
 		$contents = [];
@@ -39,15 +39,15 @@ class InvSeeEnderInventory extends ChestInventory implements InvSeeInventory{
 		$server->saveOfflinePlayerData($this->spying, $nbt);
 	}
 
-	public function syncPlayerAction(SlotChangeAction $action) : void{
+	public function syncPlayerAction(SlotChangeAction $action): void {
 		$this->setItem($action->getSlot(), $action->getTargetItem());
 	}
 
-	public function syncSpyerAction(Player $spying, SlotChangeAction $action) : void{
+	public function syncSpyerAction(Player $spying, SlotChangeAction $action): void {
 		$spying->getEnderChestInventory()->setItem($action->getSlot(), $action->getTargetItem());
 	}
 
-	public function getSpyerContents() : array{
+	public function getSpyerContents(): array {
 		$server = Server::getInstance();
 		$player_instance = $server->getPlayerExact($this->spying);
 

--- a/src/BlockHorizons/InvSee/inventories/InvSeeEnderInventoryProcessor.php
+++ b/src/BlockHorizons/InvSee/inventories/InvSeeEnderInventoryProcessor.php
@@ -1,0 +1,24 @@
+<?php
+namespace BlockHorizons\InvSee\inventories;
+
+use pocketmine\inventory\Inventory;
+use pocketmine\inventory\InventoryEventProcessor;
+use pocketmine\inventory\transaction\action\SlotChangeAction;
+use pocketmine\item\Item;
+use pocketmine\Player;
+use pocketmine\Server;
+
+class InvSeeEnderInventoryProcessor implements InventoryEventProcessor{
+
+	/** @var Player */
+	private $player;
+
+	public function __construct(Player $player){
+		$this->player = $player;
+	}
+
+	public function onSlotChange(Inventory $inventory, int $slot, Item $oldItem, Item $newItem) : ?Item{
+		Server::getInstance()->getPluginManager()->getPlugin("InvSee")->getInventoryHandler()->syncPlayerAction($this->player, new SlotChangeAction($inventory, $slot, $oldItem, $newItem));
+		return $newItem;
+	}
+}

--- a/src/BlockHorizons/InvSee/inventories/InvSeeEnderInventoryProcessor.php
+++ b/src/BlockHorizons/InvSee/inventories/InvSeeEnderInventoryProcessor.php
@@ -8,7 +8,7 @@ use pocketmine\item\Item;
 use pocketmine\Player;
 use pocketmine\Server;
 
-class InvSeeEnderInventoryProcessor implements InventoryEventProcessor{
+class InvSeeEnderInventoryProcessor implements InventoryEventProcessor {
 
 	/** @var Player */
 	private $player;

--- a/src/BlockHorizons/InvSee/inventories/InvSeeEnderInventoryProcessor.php
+++ b/src/BlockHorizons/InvSee/inventories/InvSeeEnderInventoryProcessor.php
@@ -17,7 +17,7 @@ class InvSeeEnderInventoryProcessor implements InventoryEventProcessor{
 		$this->player = $player;
 	}
 
-	public function onSlotChange(Inventory $inventory, int $slot, Item $oldItem, Item $newItem) : ?Item{
+	public function onSlotChange(Inventory $inventory, int $slot, Item $oldItem, Item $newItem): ?Item {
 		Server::getInstance()->getPluginManager()->getPlugin("InvSee")->getInventoryHandler()->syncPlayerAction($this->player, new SlotChangeAction($inventory, $slot, $oldItem, $newItem));
 		return $newItem;
 	}

--- a/src/BlockHorizons/InvSee/inventories/InvSeeInventory.php
+++ b/src/BlockHorizons/InvSee/inventories/InvSeeInventory.php
@@ -7,7 +7,7 @@ use pocketmine\inventory\Inventory;
 use pocketmine\inventory\transaction\action\SlotChangeAction;
 use pocketmine\Player;
 
-interface InvSeeInventory{
+interface InvSeeInventory {
 
 	/**
 	 * Returns the username of the player

--- a/src/BlockHorizons/InvSee/inventories/InvSeeInventory.php
+++ b/src/BlockHorizons/InvSee/inventories/InvSeeInventory.php
@@ -15,7 +15,7 @@ interface InvSeeInventory{
 	 *
 	 * @return string
 	 */
-	public function getSpying() : string;
+	public function getSpying(): string;
 
 	/**
 	 * Returns whether this inventory can spy on
@@ -25,7 +25,7 @@ interface InvSeeInventory{
 	 *
 	 * @return bool
 	 */
-	public function canSpyInventory(Inventory $inventory) : bool;
+	public function canSpyInventory(Inventory $inventory): bool;
 
 	/**
 	 * Returns whether this slot can be modified.
@@ -38,19 +38,19 @@ interface InvSeeInventory{
 	 *
 	 * @return bool
 	 */
-	public function canModifySlot(Player $player, int $slot) : bool;
+	public function canModifySlot(Player $player, int $slot): bool;
 
 	/**
 	 * Force syncs player's inventory contents
 	 * with this inventory.
 	 */
-	public function syncOnline(Player $player) : void;
+	public function syncOnline(Player $player): void;
 
 	/**
 	 * Force syncs an offline player's inventory
 	 * contents with this inventory.
 	 */
-	public function syncOffline() : void;
+	public function syncOffline(): void;
 
 	/**
 	 * Syncs inventory action committed by
@@ -58,7 +58,7 @@ interface InvSeeInventory{
 	 *
 	 * @param SlotChangeAction $action
 	 */
-	public function syncPlayerAction(SlotChangeAction $action) : void;
+	public function syncPlayerAction(SlotChangeAction $action): void;
 
 	/**
 	 * Syncs inventory action committed by
@@ -68,7 +68,7 @@ interface InvSeeInventory{
 	 * @param Player $player
 	 * @param SlotChangeAction $action
 	 */
-	public function syncSpyerAction(Player $player, SlotChangeAction $action) : void;
+	public function syncSpyerAction(Player $player, SlotChangeAction $action): void;
 
 	/**
 	 * Returns the inventory contents of the
@@ -77,5 +77,5 @@ interface InvSeeInventory{
 	 *
 	 * @return Item[]
 	 */
-	public function getSpyerContents() : array;
+	public function getSpyerContents(): array;
 }

--- a/src/BlockHorizons/InvSee/inventories/InvSeeInventory.php
+++ b/src/BlockHorizons/InvSee/inventories/InvSeeInventory.php
@@ -1,0 +1,81 @@
+<?php
+namespace BlockHorizons\InvSee\inventories;
+
+use muqsit\invmenu\inventories\ChestInventory;
+
+use pocketmine\inventory\Inventory;
+use pocketmine\inventory\transaction\action\SlotChangeAction;
+use pocketmine\Player;
+
+interface InvSeeInventory{
+
+	/**
+	 * Returns the username of the player
+	 * we are spying.
+	 *
+	 * @return string
+	 */
+	public function getSpying() : string;
+
+	/**
+	 * Returns whether this inventory can spy on
+	 * the given inventory.
+	 *
+	 * @param Inventory $inventory
+	 *
+	 * @return bool
+	 */
+	public function canSpyInventory(Inventory $inventory) : bool;
+
+	/**
+	 * Returns whether this slot can be modified.
+	 * For player inventory, only slots below
+	 * 36 or armor slots can be modified.
+	 *
+	 * @param Player $player who is modifying the
+	 * slot.
+	 * @param int $slot that is being modified.
+	 *
+	 * @return bool
+	 */
+	public function canModifySlot(Player $player, int $slot) : bool;
+
+	/**
+	 * Force syncs player's inventory contents
+	 * with this inventory.
+	 */
+	public function syncOnline(Player $player) : void;
+
+	/**
+	 * Force syncs an offline player's inventory
+	 * contents with this inventory.
+	 */
+	public function syncOffline() : void;
+
+	/**
+	 * Syncs inventory action committed by
+	 * the player we are spying.
+	 *
+	 * @param SlotChangeAction $action
+	 */
+	public function syncPlayerAction(SlotChangeAction $action) : void;
+
+	/**
+	 * Syncs inventory action committed by
+	 * the spyer when the player we are
+	 * spying is online.
+	 *
+	 * @param Player $player
+	 * @param SlotChangeAction $action
+	 */
+	public function syncSpyerAction(Player $player, SlotChangeAction $action) : void;
+
+	/**
+	 * Returns the inventory contents of the
+	 * player we are spying to initialize the
+	 * inventory's contents.
+	 *
+	 * @return Item[]
+	 */
+	public function getSpyerContents() : array;
+}

--- a/src/BlockHorizons/InvSee/inventories/InvSeeInventoryTrait.php
+++ b/src/BlockHorizons/InvSee/inventories/InvSeeInventoryTrait.php
@@ -15,7 +15,7 @@ trait InvSeeInventoryTrait{
 		parent::__construct($menu, $this->getSpyerContents(), $size, $title);
 	}
 
-	public function getSpying() : string{
+	public function getSpying(): string {
 		return $this->spying;
 	}
 }

--- a/src/BlockHorizons/InvSee/inventories/InvSeeInventoryTrait.php
+++ b/src/BlockHorizons/InvSee/inventories/InvSeeInventoryTrait.php
@@ -1,0 +1,21 @@
+<?php
+namespace BlockHorizons\InvSee\inventories;
+
+use BlockHorizons\InvSee\utils\SpyingPlayerData;
+
+use muqsit\invmenu\InvMenu;
+
+trait InvSeeInventoryTrait{
+
+	/** @var string */
+	protected $spying;
+
+	public function __construct(InvMenu $menu, SpyingPlayerData $spying_player_data, int $size = null, string $title = null){
+		$this->spying = $spying_player_data->getSpying();
+		parent::__construct($menu, $this->getSpyerContents(), $size, $title);
+	}
+
+	public function getSpying() : string{
+		return $this->spying;
+	}
+}

--- a/src/BlockHorizons/InvSee/inventories/InvSeeInventoryTrait.php
+++ b/src/BlockHorizons/InvSee/inventories/InvSeeInventoryTrait.php
@@ -5,7 +5,7 @@ use BlockHorizons\InvSee\utils\SpyingPlayerData;
 
 use muqsit\invmenu\InvMenu;
 
-trait InvSeeInventoryTrait{
+trait InvSeeInventoryTrait {
 
 	/** @var string */
 	protected $spying;

--- a/src/BlockHorizons/InvSee/inventories/InvSeePlayerInventory.php
+++ b/src/BlockHorizons/InvSee/inventories/InvSeePlayerInventory.php
@@ -13,7 +13,7 @@ use pocketmine\Player;
 use pocketmine\Server;
 use pocketmine\utils\TextFormat;
 
-class InvSeePlayerInventory extends DoubleChestInventory implements InvSeeInventory{
+class InvSeePlayerInventory extends DoubleChestInventory implements InvSeeInventory {
 	use InvSeeInventoryTrait;
 
 	const ARMOR_INVENTORY_MENU_SLOTS = [

--- a/src/BlockHorizons/InvSee/inventories/InvSeePlayerInventory.php
+++ b/src/BlockHorizons/InvSee/inventories/InvSeePlayerInventory.php
@@ -23,21 +23,21 @@ class InvSeePlayerInventory extends DoubleChestInventory implements InvSeeInvent
 		3 => 51
 	];
 
-	public function canSpyInventory(Inventory $inventory) : bool{
+	public function canSpyInventory(Inventory $inventory): bool {
 		return $inventory instanceof PlayerInventory || $inventory instanceof ArmorInventory;
 	}
 
-	public function canModifySlot(Player $player, int $slot) : bool{
+	public function canModifySlot(Player $player, int $slot): bool {
 		return $player->hasPermission($this->getSpying() === $player->getLowerCaseName() ? "invsee.inventory.modify.self" : "invsee.inventory.modify") && ($slot < 36 || in_array($slot, self::ARMOR_INVENTORY_MENU_SLOTS));
 	}
 
-	public function syncOnline(Player $player) : void{
+	public function syncOnline(Player $player): void {
 		$contents = $this->getContents();
 		$player->getInventory()->setContents(array_slice($contents, 0, $player->getInventory()->getSize()));
 		$player->getArmorInventory()->setContents(array_intersect_key($contents, array_flip(self::ARMOR_INVENTORY_MENU_SLOTS)));
 	}
 
-	public function syncOffline() : void{
+	public function syncOffline(): void {
 		$server = Server::getInstance();
 
 		$contents = [];
@@ -54,7 +54,7 @@ class InvSeePlayerInventory extends DoubleChestInventory implements InvSeeInvent
 		$server->saveOfflinePlayerData($this->spying, $nbt);
 	}
 
-	public function syncPlayerAction(SlotChangeAction $action) : void{
+	public function syncPlayerAction(SlotChangeAction $action): void {
 		$inventory = $action->getInventory();
 
 		if($inventory instanceof PlayerInventory){
@@ -64,7 +64,7 @@ class InvSeePlayerInventory extends DoubleChestInventory implements InvSeeInvent
 		}
 	}
 
-	public function syncSpyerAction(Player $spying, SlotChangeAction $action) : void{
+	public function syncSpyerAction(Player $spying, SlotChangeAction $action): void {
 		$slot = $action->getSlot();
 
 		if(($armor_slot = array_search($slot, self::ARMOR_INVENTORY_MENU_SLOTS, true)) !== false){
@@ -74,7 +74,7 @@ class InvSeePlayerInventory extends DoubleChestInventory implements InvSeeInvent
 		}
 	}
 
-	public function getSpyerContents() : array{
+	public function getSpyerContents(): array {
 		$server = Server::getInstance();
 		$player_instance = $server->getPlayerExact($this->spying);
 

--- a/src/BlockHorizons/InvSee/inventories/InvSeePlayerInventory.php
+++ b/src/BlockHorizons/InvSee/inventories/InvSeePlayerInventory.php
@@ -1,0 +1,102 @@
+<?php
+namespace BlockHorizons\InvSee\inventories;
+
+use muqsit\invmenu\inventories\DoubleChestInventory;
+
+use pocketmine\inventory\ArmorInventory;
+use pocketmine\inventory\Inventory;
+use pocketmine\inventory\PlayerInventory;
+use pocketmine\inventory\transaction\action\SlotChangeAction;
+use pocketmine\item\Item;
+use pocketmine\nbt\tag\ListTag;
+use pocketmine\Player;
+use pocketmine\Server;
+use pocketmine\utils\TextFormat;
+
+class InvSeePlayerInventory extends DoubleChestInventory implements InvSeeInventory{
+	use InvSeeInventoryTrait;
+
+	const ARMOR_INVENTORY_MENU_SLOTS = [
+		0 => 47,
+		1 => 48,
+		2 => 50,
+		3 => 51
+	];
+
+	public function canSpyInventory(Inventory $inventory) : bool{
+		return $inventory instanceof PlayerInventory || $inventory instanceof ArmorInventory;
+	}
+
+	public function canModifySlot(Player $player, int $slot) : bool{
+		return $player->hasPermission($this->getSpying() === $player->getLowerCaseName() ? "invsee.inventory.modify.self" : "invsee.inventory.modify") && ($slot < 36 || in_array($slot, self::ARMOR_INVENTORY_MENU_SLOTS));
+	}
+
+	public function syncOnline(Player $player) : void{
+		$contents = $this->getContents();
+		$player->getInventory()->setContents(array_slice($contents, 0, $player->getInventory()->getSize()));
+		$player->getArmorInventory()->setContents(array_intersect_key($contents, array_flip(self::ARMOR_INVENTORY_MENU_SLOTS)));
+	}
+
+	public function syncOffline() : void{
+		$server = Server::getInstance();
+
+		$contents = [];
+		foreach($this->getContents() as $slot => $item){
+			if(($armor_slot = array_search($slot, self::ARMOR_INVENTORY_MENU_SLOTS, true)) !== false){
+				$contents[] = $item->nbtSerialize($armor_slot + 100);
+			}else{
+				$contents[] = $item->nbtSerialize($slot + 9);
+			}
+		}
+
+		$nbt = $server->getOfflinePlayerData($this->spying);
+		$nbt->setTag(new ListTag("Inventory", $contents));
+		$server->saveOfflinePlayerData($this->spying, $nbt);
+	}
+
+	public function syncPlayerAction(SlotChangeAction $action) : void{
+		$inventory = $action->getInventory();
+
+		if($inventory instanceof PlayerInventory){
+			$this->setItem($action->getSlot(), $action->getTargetItem());
+		}elseif($inventory instanceof ArmorInventory){
+			$this->setItem(self::ARMOR_INVENTORY_MENU_SLOTS[$action->getSlot()], $action->getTargetItem());
+		}
+	}
+
+	public function syncSpyerAction(Player $spying, SlotChangeAction $action) : void{
+		$slot = $action->getSlot();
+
+		if(($armor_slot = array_search($slot, self::ARMOR_INVENTORY_MENU_SLOTS, true)) !== false){
+			$spying->getArmorInventory()->setItem($armor_slot, $action->getTargetItem());
+		}else{
+			$spying->getInventory()->setItem($slot, $action->getTargetItem());
+		}
+	}
+
+	public function getSpyerContents() : array{
+		$server = Server::getInstance();
+		$player_instance = $server->getPlayerExact($this->spying);
+
+		if($player_instance !== null){
+			$contents = $player_instance->getInventory()->getContents();
+			foreach($player_instance->getArmorInventory()->getContents() as $slot => $armor){
+				$contents[self::ARMOR_INVENTORY_MENU_SLOTS[$slot]] = $armor;
+			}
+		}else{
+			$contents = [];
+			foreach($server->getOfflinePlayerData($this->spying)->getListTag("Inventory") as $nbt){
+				$slot = $nbt->getByte("Slot");
+				$contents[$slot >= 100 && $slot < 104 ? self::ARMOR_INVENTORY_MENU_SLOTS[$slot - 100] : $slot - 9] = Item::nbtDeserialize($nbt);
+			}
+		}
+
+		//maybe make this configurable
+		$contents[45] = Item::get(Item::STAINED_GLASS_PANE, 15)->setCustomName("");
+		$contents[46] = Item::get(Item::STAINED_GLASS_PANE, 15)->setCustomName(TextFormat::RESET . TextFormat::AQUA . "Helmet ->");
+		$contents[49] = Item::get(Item::STAINED_GLASS_PANE, 15)->setCustomName(TextFormat::RESET . TextFormat::AQUA . "<- Chestplate | Leggings ->");
+		$contents[52] = Item::get(Item::STAINED_GLASS_PANE, 15)->setCustomName(TextFormat::RESET . TextFormat::AQUA . "<- Boots");
+		$contents[53] = Item::get(Item::STAINED_GLASS_PANE, 15)->setCustomName("");
+		return $contents;
+	}
+}

--- a/src/BlockHorizons/InvSee/utils/SpyingPlayerData.php
+++ b/src/BlockHorizons/InvSee/utils/SpyingPlayerData.php
@@ -6,7 +6,7 @@ use muqsit\invmenu\InvMenu;
 use pocketmine\Player;
 use pocketmine\Server;
 
-class SpyingPlayerData{
+class SpyingPlayerData {
 
 	/** @var InvMenu[] */
 	protected $menus = [];
@@ -26,11 +26,11 @@ class SpyingPlayerData{
 		}
 	}
 
-	public function getSpying() : string{
+	public function getSpying(): string {
 		return $this->spying;
 	}
 
-	public function add(InvMenu $menu) : void{
+	public function add(InvMenu $menu): void {
 		if(isset($this->menus[$class = get_class($menu->getInventory())])){
 			throw new \RuntimeError("Tried adding an already existing inventory.");
 		}
@@ -38,31 +38,31 @@ class SpyingPlayerData{
 		$this->menus[$class] = $menu;
 	}
 
-	public function get(string $inventory_class) : ?InvMenu{
+	public function get(string $inventory_class): ?InvMenu {
 		return $this->menus[$inventory_class] ?? null;
 	}
 
-	public function create(string $inventory_class) : InvMenu{
+	public function create(string $inventory_class): InvMenu {
 		$this->add($menu = InvMenu::create($inventory_class, $this));
 		return $menu;
 	}
 
-	public function getAll() : array{
+	public function getAll(): array {
 		return $this->menus;
 	}
 
-	public function onJoin(Player $player) : void{
+	public function onJoin(Player $player): void {
 		$this->rawUUID = $player->getRawUniqueId();
 		foreach($this->getAll() as $menu){
 			$menu->getInventory()->syncOnline($player);
 		}
 	}
 
-	public function onQuit(Player $player) : void{
+	public function onQuit(Player $player): void {
 		$this->rawUUID = null;
 	}
 
-	public function getPlayer() : ?Player{
+	public function getPlayer(): ?Player {
 		return $this->rawUUID !== null ? Server::getInstance()->getPlayerByRawUUID($this->rawUUID) : null;
 	}
 }

--- a/src/BlockHorizons/InvSee/utils/SpyingPlayerData.php
+++ b/src/BlockHorizons/InvSee/utils/SpyingPlayerData.php
@@ -1,0 +1,68 @@
+<?php
+namespace BlockHorizons\InvSee\utils;
+
+use muqsit\invmenu\InvMenu;
+
+use pocketmine\Player;
+use pocketmine\Server;
+
+class SpyingPlayerData{
+
+	/** @var InvMenu[] */
+	protected $menus = [];
+
+	/** @var string */
+	protected $spying;
+
+	/** @var string|null */
+	protected $rawUUID;
+
+	public function __construct(string $spying){
+		$this->spying = $spying;
+
+		$player = Server::getInstance()->getPlayerExact($spying);
+		if($player !== null){
+			$this->rawUUID = $player->getRawUniqueId();
+		}
+	}
+
+	public function getSpying() : string{
+		return $this->spying;
+	}
+
+	public function add(InvMenu $menu) : void{
+		if(isset($this->menus[$class = get_class($menu->getInventory())])){
+			throw new \RuntimeError("Tried adding an already existing inventory.");
+		}
+
+		$this->menus[$class] = $menu;
+	}
+
+	public function get(string $inventory_class) : ?InvMenu{
+		return $this->menus[$inventory_class] ?? null;
+	}
+
+	public function create(string $inventory_class) : InvMenu{
+		$this->add($menu = InvMenu::create($inventory_class, $this));
+		return $menu;
+	}
+
+	public function getAll() : array{
+		return $this->menus;
+	}
+
+	public function onJoin(Player $player) : void{
+		$this->rawUUID = $player->getRawUniqueId();
+		foreach($this->getAll() as $menu){
+			$menu->getInventory()->syncOnline($player);
+		}
+	}
+
+	public function onQuit(Player $player) : void{
+		$this->rawUUID = null;
+	}
+
+	public function getPlayer() : ?Player{
+		return $this->rawUUID !== null ? Server::getInstance()->getPlayerByRawUUID($this->rawUUID) : null;
+	}
+}


### PR DESCRIPTION
# InvSee v1.0 Release
## Bug Fixes:
- Fixed various bugs where an InvSee inventory would be out of sync with an online player's inventory if the inventory transaction was not authored by the player (eg: `/give player dirt` — the InvSee inventory doesn't sync the dirt item). This was solved by listening to `EntityArmorChangeEvent`, `EntityInventoryChangeEvent`, and installing an event processor in online players' `EnderChestInventory`.
- Fixed undefined method `InvSeeCommand::sendPermissionMessage()` (#2)
## Changes:
- Added child permissions `invsee.inventory.modify.self`, `invsee.enderinventory.modify.self` to allow players to modify their own inventory / ender inventory (yes, you can spy on your own inventory realtime!). This could be useful if someone would like to write an `/enderchest` plugin (or if we end up adding it as a feature in InvSee).
- Simplified inventory transaction handling by splitting it into various classes than having them all congested into one. It's still not that great, but it's an improvement.
- Removed `InventoryHandler::viewInventory()` and `InventoryHandler::viewEnderInventory()`. These methods have been replaced by:
  `@param Player $viewer the spyer`
  `@param string $playername the full name of the player you'd like to spy on`
  - `InventoryHandler::send($viewer, $playername, InventoryHandler::TYPE_PLAYER_INVENTORY);`
  - `InventoryHandler::send($viewer, $playername, InventoryHandler::TYPE_ENDER_INVENTORY);`